### PR TITLE
Clear Bad Data 

### DIFF
--- a/Cfa533Rs232Driver/Internal/InternalExtensions.cs
+++ b/Cfa533Rs232Driver/Internal/InternalExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Petrsnd.Cfa533Rs232Driver.Internal
+﻿using System.Collections.Generic;
+
+namespace Petrsnd.Cfa533Rs232Driver.Internal
 {
     internal static class InternalExtensions
     {
@@ -27,6 +29,12 @@
                 default:
                     return KeyFlags.Cancel;
             }
+        }
+
+        public static void RemoveFirst<T>(this Queue<T> queue, int count)
+        {
+            for (var i = 0; i < count && queue.Count > 0; i++)
+                queue.Dequeue();
         }
     }
 }


### PR DESCRIPTION
Occasionally bad data appears on the wire if you are really pounding on the keypad.  It doesn't seem to happen often and I've only ever seen it at 115200 baud rate, but previously there was no way to clear it from the read buffer.  I've implemented a sliding window that looks for a valid packet then trims any initial bytes that don't form a properly encoded packet.  This seems to fix the problem where the LCD would stop responding properly to keypad events and new commands due to bad data on the wire.